### PR TITLE
SDAP-62 Fix No bean named 'pythonChainProcessor' available bug 

### DIFF
--- a/src/main/java/org/apache/sdap/ningester/configuration/AppConfig.java
+++ b/src/main/java/org/apache/sdap/ningester/configuration/AppConfig.java
@@ -34,7 +34,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.annotation.Order;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
@@ -44,7 +43,6 @@ import java.util.Collections;
 import java.util.List;
 
 @Configuration
-@Order(1)
 @EnableConfigurationProperties({ApplicationProperties.class})
 public class AppConfig {
 

--- a/src/main/java/org/apache/sdap/ningester/configuration/BatchConfig.java
+++ b/src/main/java/org/apache/sdap/ningester/configuration/BatchConfig.java
@@ -34,11 +34,10 @@ import org.springframework.batch.item.ItemWriter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
@@ -107,36 +106,31 @@ public class BatchConfig {
      * Item Processor beans defined below
      */
     @Bean
-    @ConditionalOnBean(AddDatasetName.class)
-    @DependsOn("addDatasetNameBean")
+    @ConditionalOnProperty(prefix = "ningester.addDatasetName", name = "enabled")
     protected ItemProcessor<NexusTile, NexusTile> addDatasetName(AddDatasetName addDatasetNameBean) {
         return addDatasetNameBean::addDatasetName;
     }
 
     @Bean
-    @ConditionalOnBean(AddDayOfYearAttribute.class)
-    @DependsOn("addDayOfYearAttributeBean")
+    @ConditionalOnProperty(prefix = "ningester.addDayOfYearAttribute", name = "enabled")
     protected ItemProcessor<NexusTile, NexusTile> addDayOfYearAttribute(AddDayOfYearAttribute addDayOfYearAttributeBean) {
         return addDayOfYearAttributeBean::setDayOfYearFromGranuleName;
     }
 
     @Bean
-    @ConditionalOnBean(AddTimeFromGranuleName.class)
-    @DependsOn("addTimeFromGranuleNameBean")
+    @ConditionalOnProperty(prefix = "ningester.addTimeFromGranuleName", name = "enabled")
     protected ItemProcessor<NexusTile, NexusTile> addTimeFromGranuleName(AddTimeFromGranuleName addTimeFromGranuleNameBean) {
         return addTimeFromGranuleNameBean::setTimeFromGranuleName;
     }
 
     @Bean
-    @ConditionalOnBean(GenerateTileId.class)
-    @DependsOn("generateTileIdBean")
+    @ConditionalOnProperty(prefix = "ningester.generateTileId", name = "enabled")
     protected ItemProcessor<NexusTile, NexusTile> generateTileId(GenerateTileId generateTileIdBean) {
         return generateTileIdBean::addTileId;
     }
 
     @Bean
-    @ConditionalOnBean(PythonChainProcessor.class)
-    @DependsOn("pythonChainProcessorBean")
+    @ConditionalOnProperty(prefix = "ningester.pythonChainProcessor", name = "enabled")
     protected ItemProcessor<NexusTile, NexusTile> pythonChainProcessor(PythonChainProcessor pythonChainProcessorBean) {
         return pythonChainProcessorBean::nexusTileProcessor;
     }

--- a/src/main/java/org/apache/sdap/ningester/configuration/BatchConfig.java
+++ b/src/main/java/org/apache/sdap/ningester/configuration/BatchConfig.java
@@ -38,13 +38,12 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Import;
-import org.springframework.core.annotation.Order;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 
 @Configuration
-@Order(2)
 @EnableBatchProcessing
 @Import(AppConfig.class)
 public class BatchConfig {
@@ -109,30 +108,35 @@ public class BatchConfig {
      */
     @Bean
     @ConditionalOnBean(AddDatasetName.class)
+    @DependsOn("addDatasetNameBean")
     protected ItemProcessor<NexusTile, NexusTile> addDatasetName(AddDatasetName addDatasetNameBean) {
         return addDatasetNameBean::addDatasetName;
     }
 
     @Bean
     @ConditionalOnBean(AddDayOfYearAttribute.class)
+    @DependsOn("addDayOfYearAttributeBean")
     protected ItemProcessor<NexusTile, NexusTile> addDayOfYearAttribute(AddDayOfYearAttribute addDayOfYearAttributeBean) {
         return addDayOfYearAttributeBean::setDayOfYearFromGranuleName;
     }
 
     @Bean
     @ConditionalOnBean(AddTimeFromGranuleName.class)
+    @DependsOn("addTimeFromGranuleNameBean")
     protected ItemProcessor<NexusTile, NexusTile> addTimeFromGranuleName(AddTimeFromGranuleName addTimeFromGranuleNameBean) {
         return addTimeFromGranuleNameBean::setTimeFromGranuleName;
     }
 
     @Bean
     @ConditionalOnBean(GenerateTileId.class)
+    @DependsOn("generateTileIdBean")
     protected ItemProcessor<NexusTile, NexusTile> generateTileId(GenerateTileId generateTileIdBean) {
         return generateTileIdBean::addTileId;
     }
 
     @Bean
     @ConditionalOnBean(PythonChainProcessor.class)
+    @DependsOn("pythonChainProcessorBean")
     protected ItemProcessor<NexusTile, NexusTile> pythonChainProcessor(PythonChainProcessor pythonChainProcessorBean) {
         return pythonChainProcessorBean::nexusTileProcessor;
     }

--- a/src/test/java/org/apache/sdap/ningester/processors/AddDayOfYearAttributeTest.java
+++ b/src/test/java/org/apache/sdap/ningester/processors/AddDayOfYearAttributeTest.java
@@ -36,8 +36,8 @@ public class AddDayOfYearAttributeTest {
 
     @Test
     public void testSuccessfulMatch() {
-        String regex = "^(\\d{3})";
-        String granuleName = "001.L4_5day_avhrr_clim_sst_pixelMean.nc";
+        String regex = "^.*(\\d{3})";
+        String granuleName = "file:/some/path/001.L4_5day_avhrr_clim_sst_pixelMean.nc";
         NexusTile nexusTile = NexusTile.newBuilder().setSummary(
                 TileSummary.newBuilder()
                         .setGranule(granuleName)

--- a/src/test/java/org/apache/sdap/ningester/processors/AddTimeFromGranuleNameTest.java
+++ b/src/test/java/org/apache/sdap/ningester/processors/AddTimeFromGranuleNameTest.java
@@ -43,8 +43,37 @@ public class AddTimeFromGranuleNameTest {
         String regex = "^.*(\\d{7})\\.";
         String dateFormat = "yyyyDDD";
 
-        String granuleName = "A2012001.L3m_DAY_NSST_sst_4km.nc";
+        String granuleName = "file:/some/path/A2012001.L3m_DAY_NSST_sst_4km.nc";
         Long expectedTime = 1325376000L; // 01/01/2012 00:00:00 in epoch time
+        NexusTile nexusTile = NexusTile.newBuilder().setSummary(
+                TileSummary.newBuilder()
+                        .setGranule(granuleName)
+                        .build()
+        ).setTile(
+                TileData.newBuilder()
+                        .setGridTile(
+                                GridTile.newBuilder(
+
+                                ).build()
+                        ).build()
+        ).build();
+
+        AddTimeFromGranuleName processor = new AddTimeFromGranuleName(regex, dateFormat);
+
+        NexusTile result = processor.setTimeFromGranuleName(nexusTile);
+
+        assertThat(result.getTile().getGridTile().getTime(), is(expectedTime));
+        assertThat(result.getSummary().getStats().getMinTime(), is(expectedTime));
+        assertThat(result.getSummary().getStats().getMaxTime(), is(expectedTime));
+    }
+
+    @Test
+    public void testSuccessfulMatchAvhrr() {
+        String regex = "^.*(\\d{3})\\.";
+        String dateFormat = "DDD";
+
+        String granuleName = "file:/some/path/005.L4_5day_avhrr_clim_sst_pixelMean.nc";
+        Long expectedTime = 345600L; // 01/05/1979 00:00:00 in epoch time
         NexusTile nexusTile = NexusTile.newBuilder().setSummary(
                 TileSummary.newBuilder()
                         .setGranule(granuleName)

--- a/src/testJobs/java/org/apache/sdap/ningester/testjobs/AvhrrClimJobTest.java
+++ b/src/testJobs/java/org/apache/sdap/ningester/testjobs/AvhrrClimJobTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.sdap.ningester.testjobs;
+
+import org.apache.sdap.ningester.configuration.properties.ApplicationProperties;
+import org.apache.sdap.ningester.configuration.properties.DatasourceProperties;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.cassandra.core.CassandraTemplate;
+import org.springframework.data.solr.core.SolrTemplate;
+import org.springframework.data.solr.core.query.SimpleQuery;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.apache.sdap.ningester.testjobs.TestUtils.assertEqualsEventually;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@TestPropertySource(properties = {"spring.config.location = classpath:testjobs/AvhrrClimJobTest.yml"})
+@ActiveProfiles({"test", "cassandra", "solr"})
+public class AvhrrClimJobTest {
+
+    @Autowired
+    JobLauncherTestUtils jobLauncherTestUtils;
+    @Autowired
+    CassandraTemplate cassandraTemplate;
+    @Autowired
+    SolrTemplate solrTemplate;
+    @Autowired
+    DatasourceProperties datasourceProperties;
+    @Autowired
+    ApplicationProperties applicationProperties;
+
+    @Before
+    public void emptyDatabase() {
+        solrTemplate.delete(datasourceProperties.getSolrStore().getCollection(), new SimpleQuery("*:*"));
+        cassandraTemplate.truncate(datasourceProperties.getCassandraStore().getTableName());
+    }
+
+    @Test
+    public void testJobCompletes() throws Exception {
+
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addString("granule", "classpath:granules/001.L4_5day_avhrr_clim_sst_pixelMean.nc")
+                .toJobParameters();
+
+        JobExecution jobExecution = jobLauncherTestUtils.launchJob(jobParameters);
+
+        assertThat(jobExecution.getExitStatus().getExitCode(), is("COMPLETED"));
+        StepExecution stepExecution = jobExecution.getStepExecutions().iterator().next();
+        assertThat(stepExecution.getReadCount(), is(1296));
+        assertThat(stepExecution.getWriteCount(), is(1053));
+        assertThat(stepExecution.getFilterCount(), is(243));
+
+        assertEqualsEventually(1053L,
+                () -> solrTemplate.count(datasourceProperties.getSolrStore().getCollection(),
+                        new SimpleQuery("dataset_s: " + applicationProperties.getAddDatasetName().getDatasetName())),
+                3);
+
+        long cassandraCount = cassandraTemplate.count(datasourceProperties.getCassandraStore().getTableName());
+
+        assertThat(cassandraCount, is(1053L));
+    }
+
+    @TestConfiguration
+    static class NingesterApplicationTestsConfig {
+
+        @Bean
+        JobLauncherTestUtils jobLauncherTestUtils() {
+            return new JobLauncherTestUtils();
+        }
+
+    }
+
+
+}

--- a/src/testJobs/resources/testjobs/AvhrrClimJobTest.yml
+++ b/src/testJobs/resources/testjobs/AvhrrClimJobTest.yml
@@ -1,0 +1,70 @@
+# Tile Slicer Config
+ningester:
+  tile_slicer: sliceFileByTilesDesired
+  sliceFileByTilesDesired:
+    tilesDesired: 1296
+    timeDimension: time
+    dimensions:
+      - lat
+      - lon
+---
+# Tile processors configuration
+ningester:
+  tile_processors:
+    - pythonChainProcessor
+    - generateTileId
+    - addTimeFromGranuleName
+    - addDayOfYearAttribute
+    - addDatasetName
+  pythonChainProcessor:
+    enabled:
+    processor_list:
+      -
+        name: GridReadingProcessor
+        config:
+          latitude: lat
+          longitude: lon
+          time: time
+          variable_to_read: analysed_sst
+      -
+        name: EmptyTileFilter
+      -
+        name: KelvinToCelsius
+      -
+        name: TileSummarizingProcessor
+        config:
+          stored_var_name: analysed_sst
+  generateTileId:
+    enabled:
+  addTimeFromGranuleName:
+    enabled:
+    regex: ^.*(\d{3})\.
+    dateFormat: DDD
+  addDayOfYearAttribute:
+    enabled:
+    regex: ^.*(\d{3})\.
+  addDatasetName:
+    enabled:
+    datasetName: AVHRR_OI_L4_GHRSST_NCEI_CLIM
+---
+# Tile writer configuration
+ningester:
+  tile_writer:
+    data_store: cassandraStore
+    metadata_store: solrStore
+---
+# Connection settings for the test profile
+spring:
+    profiles:
+      - test
+      - local
+    data:
+      cassandra:
+        keyspaceName: nexustiles
+        contactPoints: 127.0.0.1
+      solr:
+        host: http://127.0.0.1:8983/solr/
+
+datasource:
+  solrStore:
+    collection: nexustiles


### PR DESCRIPTION
the problem is the auto-configuration, the `pythonChainProcessor` that it’s complaining about is `@ConditionalOnBean(PythonChainProcessor.class)` (https://github.com/apache/incubator-sdap-ningester/blob/master/src/main/java/org/apache/sdap/ningester/configuration/BatchConfig.java#L135).

The `PythonChainProcessor.class` is `@ConditionalOnProperty(prefix = "ningester.pythonChainProcessor", name = "enabled")` (https://github.com/apache/incubator-sdap-ningester/blob/master/src/main/java/org/apache/sdap/ningester/configuration/AppConfig.java#L152).

The `PythonChainProcessor.class` bean is created but for some reason the `@ConditionalOnBean(PythonChainProcessor.class)` is failing to match (edited)

I thought I fixed it by ordering the configurations, making sure AppConfig https://github.com/apache/incubator-sdap-ningester/blob/master/src/main/java/org/apache/sdap/ningester/configuration/AppConfig.java#L47 loads before BatchConfig https://github.com/apache/incubator-sdap-ningester/blob/master/src/main/java/org/apache/sdap/ningester/configuration/BatchConfig.java#L47 (edited)


Fix is to make the `@Conditional...` annotations between the Bean and the ItemProcessorBean be identical.