### PR TITLE
SDAP-107 Ningester container does not report exit code correctly

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -13,7 +13,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# Exit immediately if a simple command returns non-zero exit code
+# Cause the status of terminated background jobs to be reported immediately.
 set -eb
+# With pipefail, the return status of a pipeline is "the value of the last (rightmost) command to exit with a non-zero status, or zero if all commands exit successfully"
+set -o pipefail
 
 NINGESTER_JAR=`find ningester/build/libs -name ningester*.jar`
 CONFIG_FILES=`find /config -name "*.yml" | awk -vORS=, '{ print $1 }'`

--- a/src/test/java/org/apache/sdap/ningester/processors/AddDayOfYearAttributeTest.java
+++ b/src/test/java/org/apache/sdap/ningester/processors/AddDayOfYearAttributeTest.java
@@ -75,6 +75,28 @@ public class AddDayOfYearAttributeTest {
         processor.setDayOfYearFromGranuleName(nexusTile);
     }
 
+    @Test
+    public void testSuccessfulMatchSmap() {
+        String regex = "^sss_smap_L3m_clim_doy(\\d{3}).*";
+        String granuleName = "file:/some/path/sss_smap_L3m_clim_doy227_month08_nepochs1_pixelMean.nc";
+        NexusTile nexusTile = NexusTile.newBuilder().setSummary(
+                TileSummary.newBuilder()
+                        .setGranule(granuleName)
+                        .build()
+        ).build();
+
+        AddDayOfYearAttribute processor = new AddDayOfYearAttribute(regex);
+
+        NexusTile result = processor.setDayOfYearFromGranuleName(nexusTile);
+
+        assertThat(result.getSummary().getGlobalAttributesList(), contains(
+                hasProperty("name", is("day_of_year_i"))
+        ));
+
+        String actualDayOfYear = result.getSummary().getGlobalAttributes(0).getValues(0);
+        assertThat(actualDayOfYear, is("227"));
+    }
+
     @Test()
     public void testUnsuccessfulGroupMatch() {
 


### PR DESCRIPTION
Because I was using a pipe to prepend text to every log line, when the java command failed the exit status was being overwritten by the exit status of the sed command effectively making it 0. This caused the container to exit with code 0 and would show up as a successful job completion in kubernetes.

Fix was to use `set -o pipefail` in entrypoint script.